### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ jobs:
           echo 'Files modified: ${{steps.files.outputs.files_updated}}'
           echo 'Files added: ${{steps.files.outputs.files_created}}'
           echo 'Files removed: ${{steps.files.outputs.files_deleted}}'
-      - uses: Arhia/action-check-typescript@v2.0
+      - uses: Arhia/action-check-typescript@v0.11
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           use-check: true
@@ -58,9 +58,7 @@ jobs:
 ```
 ## Customize the check  
 
-By default, this action doesn't perform a status check (aka pass/fail).  
-
-You need to set `use-check` on true to run a status check.    
+By default, this action performs a status check (aka pass/fail). 
 
 ```yaml
   use-check: true


### PR DESCRIPTION
- updated Arhia/action-check-typescript version to reference a real version (using @v2.0 fails the action because it does not exist)
- updated explanation that the checker *does* run by default