### PR TITLE
Update usage example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ jobs:
           include: '["\\.ts$"]'
       - name: Detecting files changed
         id: files
-        uses: futuratrepadeira/changed-files@v3.3.0
+        uses: umani/changed-files@v4.0.0
         with:
           repo-token: ${{ github.token }}
           pattern: '^.*\.ts$'


### PR DESCRIPTION
Replaced the usage example of `futuratrepadeira/changed-files` GH action with `umani/changed-files` as user account is renamed.