### PR TITLE
part of #170 : Support editing existing comment if one exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ jobs:
           files-deleted: ${{steps.files.outputs.files_deleted}}
           line-numbers: ${{steps.diff.outputs.lineNumbers}}
           output-behaviour: both
+          comment-behaviour: new
 ```
 ## Customize the check  
 
@@ -82,6 +83,13 @@ Value|Behaviour
 `comment` | Default, comments on the PR with the errors found for this run.
 `annotate` | Uses github line annotations with the errors found for this run.
 `both` | Does both of the above.
+
+The comment behaviour depends on the value of `comment-behaviour`
+
+Value|Behaviour
+-- | --
+`new` | Default, adds a new comment for every run of the action.
+`edit` | Updates a previous run's comment, if one exists, otherwise creates a new comment.
 
 ## Use a specific tsconfig file
 

--- a/action.yml
+++ b/action.yml
@@ -1,39 +1,42 @@
-name: 'Action Check Typescript errors'
-description: 'Check tsc errors and compare errors wih base branch'
-author: 'Arhia'
+name: "Action Check Typescript errors"
+description: "Check tsc errors and compare errors wih base branch"
+author: "Arhia"
 icon: box
 inputs:
   repo-token:
-    description: 'Token for the repository. Can be passed in using {{ secrets.GITHUB_TOKEN }}'
+    description: "Token for the repository. Can be passed in using {{ secrets.GITHUB_TOKEN }}"
     required: true
   directory:
     description: "Directory where to run install and build. Default is '.'"
-    default: '.'
+    default: "."
   files-changed:
     description: "List of files changed in the current PR (separated by space), use action 'futuratrepadeira/changed-files' for that"
-    default: ''
+    default: ""
   files-added:
     description: "List of files added in the current PR (separated by space), use action 'futuratrepadeira/changed-files' for that"
-    default: ''
+    default: ""
   files-deleted:
     description: "List of files deleted in the current PR (separated by space), use action 'futuratrepadeira/changed-files' for that"
-    default: ''
+    default: ""
   line-numbers:
     description: "List of files with added and removed lines, use action 'Equip-Collaboration/diff-line-numbers' for that"
   ts-config-path:
     description: "Path of tsconfig file. default is './tsconfig.json'"
-    default: './tsconfig.json'
+    default: "./tsconfig.json"
   use-check:
-    description: 'Report status as a CI Check'
+    description: "Report status as a CI Check"
   check-fail-mode:
     description: "Allowed values : added, errors_in_pr, errors_in_code"
     required: true
   output-behaviour:
     description: "Allowed values : comment, annotate, both"
     default: "comment"
+  comment-behaviour:
+    description: "Allowed values : new, edit"
+    default: "new"
   debug:
     description: "Set true to log ts errors in base branch and pr branch"
     default: false
 runs:
-  using: 'node16'
-  main: 'dist/index.js'
+  using: "node16"
+  main: "dist/index.js"

--- a/src/getAndValidateArgs.ts
+++ b/src/getAndValidateArgs.ts
@@ -12,6 +12,11 @@ export const enum OUTPUT_BEHAVIOUR {
   COMMENT_AND_ANNOTATE = 'both'
 }
 
+export const enum COMMENT_BEHAVIOUR {
+  NEW = 'new',
+  EDIT = 'edit'
+}
+
 type Args = {
   repoToken: string
   directory: string
@@ -47,6 +52,7 @@ type Args = {
   useCheck: boolean
   checkFailMode: CHECK_FAIL_MODE
   outputBehaviour: OUTPUT_BEHAVIOUR
+  commentBehaviour: COMMENT_BEHAVIOUR
   debug: boolean
 }
 
@@ -62,6 +68,7 @@ export function getAndValidateArgs(): Args {
     useCheck: getBooleanInput('use-check'),
     checkFailMode: getInput('check-fail-mode', { required: true }) as CHECK_FAIL_MODE,
     outputBehaviour: getInput('output-behaviour') as OUTPUT_BEHAVIOUR,
+    commentBehaviour: getInput('comment-behaviour') as COMMENT_BEHAVIOUR,
     debug: getBooleanInput('debug')
   }
 
@@ -79,6 +86,13 @@ export function getAndValidateArgs(): Args {
     OUTPUT_BEHAVIOUR.COMMENT_AND_ANNOTATE
   ].includes(args.outputBehaviour)) {
     throw new Error(`Invalid value ${args.outputBehaviour} for input output-behaviour`)
+  }
+
+  if (![
+    COMMENT_BEHAVIOUR.NEW,
+    COMMENT_BEHAVIOUR.EDIT,
+  ].includes(args.commentBehaviour)) {
+    throw new Error(`Invalid value ${args.commentBehaviour} for input comment-behaviour`)
   }
 
   return args

--- a/src/getBodyComment.ts
+++ b/src/getBodyComment.ts
@@ -1,6 +1,7 @@
 import { ErrorTs } from "./main"
 
 const BLANK_LINE = '  \n'
+export const COMMENT_TITLE = '## Typescript errors check'
 
 type Input = {
     errorsInProjectBefore: ErrorTs[]
@@ -13,7 +14,7 @@ type Input = {
 export function getBodyComment({ errorsInProjectBefore, errorsInProjectAfter, errorsInModifiedFiles, newErrorsInProject }: Input): string {
 
     const delta = errorsInProjectAfter.length - errorsInProjectBefore.length
-    let s = `## Typescript errors check  \n`
+    let s = `${COMMENT_TITLE}  \n`
 
     const areStillErrors = !!errorsInProjectAfter.length
 


### PR DESCRIPTION
This PR adds a new option for whether to update the existing comment from a previous run of the action, or whether to create a new comment. Defaults to creating a new comment for backwards compatibility.

@abenhamdine fyi! 😄 